### PR TITLE
The Waypoint constructor as-id doesn't work with newer versions of Leaflet

### DIFF
--- a/src/L.Routing.TomTom.js
+++ b/src/L.Routing.TomTom.js
@@ -232,7 +232,7 @@
                 idx;
 
             wpIndices.push(0);
-            wps.push(new L.Routing.Waypoint(coordinates[0], waypoints[0].name));
+            wps.push({ latLng: coordinates[0], name: waypoints[0].name });
 
             for (i = 0; i < instructions.length; i++) {
                 if (instructions[i].type === "WaypointReached") {


### PR DESCRIPTION
I'm using 1.3.1.